### PR TITLE
Hdr for lz4 format

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -183,11 +183,11 @@ void writePNG(Image image, const char* filename) {
 	}
 }
 
-Image readHDR(const char* filename, bool storeHdr) {
+Image readHDR(const char* filename, bool storeHdr, int storeComponents) {
 	int width, height, n;
 	if (storeHdr) {
-		float *data = stbi_loadf(filename, &width, &height, &n, 4);
-		Image image = Image(NULL, width, height, n);
+		float *data = stbi_loadf(filename, &width, &height, &n, storeComponents);
+		Image image = Image(NULL, width, height, storeComponents);
 		image.isHdr = true;
 		image.hdrPixels = data;
 		return image;
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
 
 	Image image(NULL, 0, 0);
 	if (endsWith(from, ".png")) image = readPNG(from.c_str());
-	else if (endsWith(from, ".hdr")) image = readHDR(from.c_str(), format == "hdr" || format == "lz4");
+	else if (endsWith(from, ".hdr")) image = readHDR(from.c_str(), format == "hdr" || format == "lz4", format == "lz4" ? 4 : 3);
 	else image = readJPEG(from.c_str());
 
 	if (scale != 1) {

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -186,7 +186,7 @@ void writePNG(Image image, const char* filename) {
 Image readHDR(const char* filename, bool storeHdr) {
 	int width, height, n;
 	if (storeHdr) {
-		float *data = stbi_loadf(filename, &width, &height, &n, 0);
+		float *data = stbi_loadf(filename, &width, &height, &n, 4);
 		Image image = Image(NULL, width, height, n);
 		image.isHdr = true;
 		image.hdrPixels = data;
@@ -318,7 +318,7 @@ int main(int argc, char** argv) {
 
 	Image image(NULL, 0, 0);
 	if (endsWith(from, ".png")) image = readPNG(from.c_str());
-	else if (endsWith(from, ".hdr")) image = readHDR(from.c_str(), format == "hdr");
+	else if (endsWith(from, ".hdr")) image = readHDR(from.c_str(), format == "hdr" || format == "lz4");
 	else image = readJPEG(from.c_str());
 
 	if (scale != 1) {
@@ -363,7 +363,7 @@ int main(int argc, char** argv) {
 		image = transparent(image, transparentColor);
 	}
 
-	if (doprealpha && !dobackground) {
+	if (doprealpha && !dobackground && !image.isHdr) {
 		image = prealpha(image);
 	}
 
@@ -395,10 +395,18 @@ int main(int argc, char** argv) {
 		writeK(image.width, image.height, "SNAP", compressed, compressedSize, to.c_str());
 	}
 	else if (format == "lz4") {
-		int max = LZ4_compressBound(image.stride * image.height);
-		char* compressed = new char[max];
-		int compressedSize = LZ4_compress_default((char*)image.pixels, compressed, image.stride * image.height, max);
-		writeK(image.width, image.height, "LZ4 ", compressed, compressedSize, to.c_str());
+		if (image.isHdr) {
+			int max = LZ4_compressBound(image.width * image.height * 16);
+			char* compressed = new char[max];
+			int compressedSize = LZ4_compress_default((char*)image.hdrPixels, compressed, image.width * image.height * 16, max);
+			writeK(image.width, image.height, "LZ4F", compressed, compressedSize, to.c_str());
+		}
+		else {
+			int max = LZ4_compressBound(image.stride * image.height);
+			char* compressed = new char[max];
+			int compressedSize = LZ4_compress_default((char*)image.pixels, compressed, image.stride * image.height, max);
+			writeK(image.width, image.height, "LZ4 ", compressed, compressedSize, to.c_str());
+		}
 	}
 	else {
 		Directory dir = openDir("Datatypes");


### PR DESCRIPTION
Adds support for writing float RGBA texture data compressed using lz4 into .k files. With some Kore additions we should be able to also omit alpha channel.

Edit: I went with the 'LZ4F' tag, let me know if there is a cleaner way to indicate that floats are stored.