### PR TITLE
Enable FreeBSD binaries to be built

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -25,8 +25,8 @@ jobs:
       with:
         usesh: true
         mem: 2048
-        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi gcc
-        run: node Kinc/make --compile
+        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi
+        run: node Kinc/make --compile --compiler clang
     - name: Get kraffiti_bin
       run: git clone https://github.com/Kode/kraffiti_bin.git
     - name: Copy binary

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,47 @@
+name: Linux
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get Submodules
+      run: git submodule update --init --recursive
+    - name: Get Kinc
+      run: git clone --recursive https://github.com/Kode/Kinc.git
+    - name: Compile in FreeBSD VM
+      id: build
+      uses: vmactions/freebsd-vm@v0.1.3
+      with:
+        usesh: true
+        mem: 2048
+        prepare: pkg install -y node alsa-lib libXinerama mesa-libs libXi gcc
+        run: node Kinc/make --compile
+    - name: Get kraffiti_bin
+      run: git clone https://github.com/Kode/kraffiti_bin.git
+    - name: Copy binary
+      run: cp build/Release/kraffiti kraffiti_bin/kraffiti-freebsd
+    - name: Set name
+      run: git config --global user.name "Robbot"
+    - name: Set email
+      run: git config --global user.email "robbot2019@robdangero.us"
+    - name: Add binary
+      run: git -C kraffiti_bin add -A
+    - name: Commit binary
+      run: git -C kraffiti_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
+    - name: Tag binary
+      run: git -C kraffiti_bin tag freebsd_$GITHUB_SHA
+    - name: Push binary
+      run: git -C kraffiti_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/kraffiti_bin.git master --tags
+      env:
+        ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - FreeBSD-Build
   pull_request:
     branches:
     - master
@@ -12,7 +13,7 @@ jobs:
   build:
 
     runs-on: macos-latest
-
+    name: FreeBSD build
     steps:
     - uses: actions/checkout@v1
     - name: Get Submodules

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Get Kinc
       run: git clone --recursive https://github.com/Kode/Kinc.git
     - name: Change to own submodule url
-      run: git -C Kinc config --file=.gitmodules submodule.kincmake.url https://github.com/tcdude/kincmake.git
+      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.url https://github.com/tcdude/kincmake.git
     - name: Change to FreeBSD-Build branch
-      run: git -C Kinc config --file=.gitmodules submodule.kincmake.branch FreeBSD-Build
+      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.branch FreeBSD-Build
     - name: Sync submodule
       run: git -C Kinc submodule sync
     - name: Update submodule

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,4 +1,4 @@
-name: Linux
+name: FreeBSD
 
 on:
   push:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - FreeBSD-Build
   pull_request:
     branches:
     - master
@@ -20,14 +19,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Get Kinc
       run: git clone --recursive https://github.com/Kode/Kinc.git
-    - name: Change to own submodule url
-      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.url https://github.com/tcdude/kincmake.git
-    - name: Change to FreeBSD-Build branch
-      run: git -C Kinc config --file=.gitmodules submodule.Tools/kincmake.branch FreeBSD-Build
-    - name: Sync submodule
-      run: git -C Kinc submodule sync
-    - name: Update submodule
-      run: git -C Kinc submodule update --init --recursive --remote
     - name: Compile in FreeBSD VM
       id: build
       uses: vmactions/freebsd-vm@v0.1.3

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -20,6 +20,14 @@ jobs:
       run: git submodule update --init --recursive
     - name: Get Kinc
       run: git clone --recursive https://github.com/Kode/Kinc.git
+    - name: Change to own submodule url
+      run: git -C Kinc config --file=.gitmodules submodule.kincmake.url https://github.com/tcdude/kincmake.git
+    - name: Change to FreeBSD-Build branch
+      run: git -C Kinc config --file=.gitmodules submodule.kincmake.branch FreeBSD-Build
+    - name: Sync submodule
+      run: git -C Kinc submodule sync
+    - name: Update submodule
+      run: git -C Kinc submodule update --init --recursive --remote
     - name: Compile in FreeBSD VM
       id: build
       uses: vmactions/freebsd-vm@v0.1.3


### PR DESCRIPTION
This adds a github action to build a FreeBSD binary. 

> Note: This will only work once [this PR](https://github.com/Kode/kincmake/pull/113) is merged into `kincmake`!